### PR TITLE
OCD-960: remove duplicate cps in production

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## Version TBD
+_Date TBD_
+
+### Changes
+* Added script to remove three specific duplicate certified products
+
+---
+
 ## Version 5.2.0
 _21 October 2016_
 

--- a/ocd-960.sql
+++ b/ocd-960.sql
@@ -1,0 +1,35 @@
+CREATE FUNCTION openchpl.deleteDuplicateCertifiedProducts() RETURNS integer AS $$
+DECLARE
+	duplicates integer;
+BEGIN
+--see how many duplicates there are.
+-- we expect 3 and we know which ones to delete.
+-- if there are not 3, we should raise an error and not continue.
+	SELECT count(*) 
+	INTO duplicates
+	from 
+		(SELECT count(*), year, testing_lab_code, certification_body_code,vendor_code, product_code, version_code, 
+			 ics_code, additional_software_code, certified_date_code
+		FROM openchpl.certified_product_details
+		where year in ('2014', '2015')
+		and product_code is not null
+		group by year, testing_lab_code, certification_body_code,vendor_code, product_code, version_code, 
+			 ics_code, additional_software_code, certified_date_code
+		having count(*) > 1) dups;
+
+	IF duplicates <> 3 THEN
+		RAISE EXCEPTION '% duplicate records were found - expecting to find 3', duplicates;
+	ELSE
+		RAISE NOTICE 'Found 3 duplicate records - marking 7703, 7704, and 8001 as deleted.';
+		UPDATE openchpl.certified_product SET deleted = true where certified_product_id = 7703;
+		UPDATE openchpl.certified_product SET deleted = true where certified_product_id = 7704;
+		UPDATE openchpl.certified_product SET deleted = true where certified_product_id = 8001;
+	END IF;
+	
+	RETURN duplicates;
+END
+$$ LANGUAGE plpgsql;
+
+select openchpl.deleteDuplicateCertifiedProducts();
+
+DROP FUNCTION openchpl.deleteDuplicateCertifiedProducts();


### PR DESCRIPTION
the script is very specific to the duplicate products we know about in production today. if there are more or less duplicates when we run this, it will fail. open to other suggestions!