### PR TITLE
fix: update activity concept 'PENDING SURVE...' to 'PENDING_SURVE...'

### DIFF
--- a/PENDING_RELEASE_NOTES.md
+++ b/PENDING_RELEASE_NOTES.md
@@ -5,4 +5,7 @@ _Date TBD_
 ### Table modifications
 * Add error and warning count to pending listing table.
 
+### Data modifications
+* Update activity concept 'PENDING SURVEIALLNCE' to 'PENDING_SURVEILLANCE'
+
 ---

--- a/ocd-2797.sql
+++ b/ocd-2797.sql
@@ -1,0 +1,2 @@
+update openchpl.activity_concept set concept='PENDING_SURVEILLANCE' where concept='PENDING SURVEILLANCE';
+ 

--- a/v-next.sql
+++ b/v-next.sql
@@ -1,4 +1,5 @@
 \i ocd-2809.sql
+\i ocd-2797.sql
 
 \i dev/openchpl_soft-delete.sql
 \i dev/openchpl_views.sql


### PR DESCRIPTION
OCD-2797

The openchpl_preload.sql already had the correct data, so it was not updated.