### PR TITLE
OCD-4058: Delete orphaned version

### DIFF
--- a/changes/ocd-4058.sql
+++ b/changes/ocd-4058.sql
@@ -1,0 +1,10 @@
+-- delete the orphaned version
+DELETE FROM openchpl.product_version
+WHERE product_version_id = 8583;
+
+-- delete version split + version creation activities
+DELETE FROM openchpl.activity
+WHERE activity_id = 89349;
+
+DELETE FROM openchpl.activity
+WHERE activity_id = 89348;


### PR DESCRIPTION
The version was created by a user when performing a split action but never had any listings assigned to it.

[#OCD-4058]