### PR TITLE
OCD-4079: Remove "key" column from ehr_certification_id table

### DIFF
--- a/changes/ocd-4079.sql
+++ b/changes/ocd-4079.sql
@@ -1,0 +1,5 @@
+ALTER TABLE openchpl.ehr_certification_id
+DROP CONSTRAINT IF EXISTS unique_year_key;
+
+ALTER TABLE openchpl.ehr_certification_id
+DROP COLUMN IF EXISTS key CASCADE;


### PR DESCRIPTION
There was a unique constraint on the "year" + "key" columns for ehr certification ids. The "key" here is a base-36 encoded hash of the listing IDs that make up the certification ID and the year could be 2015 or a hybrid 2014/2015. The unique constraint no longer applies since the same set of listings can be used to make a 0015E AND a 0015C certification ID, both with "year" 2015.

The "key" columns appears to have solely been used to enforce that unique constraint, so both the constraint and column are being removed.

[#OCD-4079]