### PR TITLE
OCD-4292 - Mark GAP Medicaid g1/g2 measures as Removed

### DIFF
--- a/changes/ocd-4292.sql
+++ b/changes/ocd-4292.sql
@@ -1,0 +1,1 @@
+update openchpl.measure set removed = true where id in (12, 14, 20, 22, 28, 30);


### PR DESCRIPTION
OCD-4292