### PR TITLE
OCD-4501 - Mark "removing code sets" as questionable activity

### DIFF
--- a/changes/ocd-4501.sql
+++ b/changes/ocd-4501.sql
@@ -1,0 +1,6 @@
+insert into openchpl.questionable_activity_trigger (name, level, last_modified_user)
+select 'Code Set has been removed', 'Certification Criteria', -1
+where not exists (
+    select *
+    from openchpl.questionable_activity_trigger
+    where name = 'Code Set has been removed');


### PR DESCRIPTION
OCD-4501